### PR TITLE
Updated dependencies to latest versions:

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
   "homepage": "https://github.com/johnie/eslint-config-airbnb-flow#readme",
   "devDependencies": {
     "ava": "*",
-    "xo": "*",
-    "eslint": "^3.6.0"
+    "eslint": "^3.6.0",
+    "flow-bin": "^0.43.1",
+    "xo": "*"
   },
   "dependencies": {
     "babel-eslint": "^7.2.1",
@@ -59,7 +60,8 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^6.3.0"
+    "eslint-plugin-react": "^6.3.0",
+    "eslint-plugin-no-use-extend-native": "^0.3.12"
   },
   "xo": {
     "esnext": true

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
     "eslint": "^3.6.0"
   },
   "dependencies": {
-    "babel-eslint": "^6.1.2",
-    "eslint-config-airbnb": "^12.0.0",
+    "babel-eslint": "^7.2.1",
+    "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-flowtype": "^2.19.0",
-    "eslint-plugin-flowtype-errors": "^1.1.0",
-    "eslint-plugin-import": "^1.16.0",
-    "eslint-plugin-jsx-a11y": "^2.2.2",
-    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-flowtype-errors": "^3.0.3",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^6.3.0"
   },
   "xo": {


### PR DESCRIPTION
babel-eslint                    ^6.1.2  →   ^7.2.1
eslint-config-airbnb           ^12.0.0  →  ^14.1.0
eslint-plugin-flowtype-errors   ^1.1.0  →   ^3.0.3
eslint-plugin-import           ^1.16.0  →   ^2.2.0
eslint-plugin-jsx-a11y          ^2.2.2  →   ^4.0.0
eslint-plugin-promise           ^2.0.1  →   ^3.5.0